### PR TITLE
Make it possible to override default column data type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,18 @@ To generate an XLSX:
 ```twig
 {% spaceless %}
 {% set options = {
-    header: ['Email', 'Name'],
+    header: ['Email', 'Name', { header: 'age', format: 'integer' }],
     rows: [
-        [ 'test@example.com', 'John Doe' ],
-        [ 'another+test@example.com', 'Jane Doe' ],
-        [ 'third+test@example.com', 'Trond Johansen' ],
+        [ 'test@example.com', 'John Doe', 31 ],
+        [ 'another+test@example.com', 'Jane Doe', 32 ],
+        [ 'third+test@example.com', 'Trond Johansen', 33 ],
     ]
 } %}
 {{ craft.beam.xlsx(options) }}
 {% endspaceless %}
 ```
+
+Note that you can also can also specify data formats for the columns. The default
+is string but PHP XLSXWriter offers [a number of data formats](https://github.com/mk-j/PHP_XLSXWriter).
 
 Brought to you by [Superbig](https://superbig.co)

--- a/services/BeamService.php
+++ b/services/BeamService.php
@@ -61,7 +61,11 @@ class BeamService extends BaseApplicationComponent
             $headers = [ ];
 
             foreach ($options['header'] as $header) {
-                $headers[ $header ] = 'string';
+                if (is_array($header)) {
+                  $headers[$header['header']] = $header['format'];
+                } else {
+                  $headers[ $header ] = 'string';
+                }
             }
 
             // Insert the headers


### PR DESCRIPTION
Hi there @sjelfull,

I had a concrete use case at work where I needed the data type for certain columns to be numerical. So, I extended this plugin to allow this. And I updated the Readme. What do you think? 